### PR TITLE
#11 fixed: transfer logic for both sol_token and spl_token

### DIFF
--- a/pump/programs/pump/src/instructions/buy_token.rs
+++ b/pump/programs/pump/src/instructions/buy_token.rs
@@ -1,8 +1,80 @@
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{mint_to, MintTo, Token},
+    metadata::{
+        create_metadata_accounts_v3,
+        mpl_token_metadata::types::DataV2,
+        CreateMetadataAccountsV3,
+        Metadata as Metaplex,
+    },
+};
+
 use anchor_lang::prelude::*;
+use crate::state::*;
 #[derive(Account)]
 pub struct BuyToken {
     #[account(mut)]
     pub signer: Signer<'info>
 
-    pub signer_token_ata:Accoun
+    #[account(
+    seeds = ["bonding_curve_sol_escrow".as_bytes(), bonding_curve.key().as_ref()],
+    bump
+     )]
+    pub sol_ata: Account<'info, SystemAccount>
+
+        #[account(
+        init_if_needed,
+        payer = signer,
+        associated_token::mint  = token_mint,
+        associated_token::authority = signer,
+    )]
+    pub token_ata: Account<'info, TokenAccount>
+
+    #[account(
+        associated_token::mint = token_mint,
+        associated_token::authority = bonding_curve
+    )]
+    pub token_escrow: Account<'info, TokenAccount>
+
+     #[account(
+        seeds = ["bonding_curve_sol_escrow".as_bytes(), bonding_curve.key().as_ref()],
+        bump,
+    )]
+    pub sol_escrow: SystemAccount<'info>
+
+    #[account(
+        seeds = [b"BONDING_CURVE", token_mint.key().as_ref()],
+        bump = bonding_curve.bump
+    )]
+    pub bonding_curve: Account<'info, BondingCurve>
+
+    #[account(
+        constants = mint::decimal == 6,
+        constants = bonding_curve.token_mint == token_mint.key()
+    )]
+    pub token_mint: Account<'info, Mint>
+
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>
+    pub associated_token_program: Program<'info, AssociatedToken>
+}
+
+pub fn buy_token(ctx:Context<BuyToken>, maxSol:u64) -> Result<()> {
+    let bonding_curve = &mut ctx.account.bonding_curve;
+    let swapAmount = bonding_curve.buy_logic(max_sol);
+    /*
+    from:  AccountInfo<'info>,
+        to: AccountInfo<'info>,
+        vault_signer_seeds: &[&[&[u8]]],
+        amount: u64,
+        token_program: &AccountInfo<'info>,
+    */
+    // User -> sol_escrow
+    bonding_curve.transfer_token(ctx.acccounts.sol_ata.to_account_info(), ctx.acccounts.sol_escrow.to_account_info(), &[], swapAmount.max_sol, ctx.acccounts.signer.to_account_info(),ctx.acccounts.token_program.to_account_info());
+    //token_escrow -> token_ata
+    let signer = &[b"BONDING_CURVE", ctx.acccounts.token_mint.key().as_ref(), &[ctx.acccounts.bonding_curve.bump]];
+    let signer_seeds:&[&[&[u8]]] = &[&signer[..]];
+
+    bonding_curve.transfer_token(ctx.accounts.token_escrow.to_account_info(), ctx.accounts.token_ata.to_account_info, signer_seeds, swapAmount.token_to_send,ctx.acccounts.bonding_curve.to_account_info(), ctx.acccounts.token_program.to_account_info());
+    Ok(())
 }

--- a/pump/programs/pump/src/instructions/create_token.rs
+++ b/pump/programs/pump/src/instructions/create_token.rs
@@ -8,6 +8,7 @@ use anchor_spl::{
         mpl_token_metadata::types::DataV2,
         CreateMetadataAccountsV3,
         Metadata as Metaplex,
+        mpl_token_metadata::ID as METAPLEX_ID,
     },
 };
 // use anchor_lang::prelude::{Mint, TokenAccount}; // ✅ Fix: Use the correct types for Anchor compatibility
@@ -27,7 +28,7 @@ pub struct CreateToken<'info> {
     #[account(
         init_if_needed,
         payer = signer,
-        seeds = ["BONDING_SEED".as_bytes(), signer.key().as_ref()],
+        seeds = ["BONDING_SEED".as_bytes(), mint.key().as_ref()],
         space = ANCHOR_DISCRIMINATOR + BondingCurve::INIT_SPACE,
         bump,
     )]
@@ -60,6 +61,7 @@ pub struct CreateToken<'info> {
     pub system_program: Program<'info, System>,
     pub rent: Sysvar<'info, Rent>,
     pub associated_token_program: Program<'info, AssociatedToken>,
+    #[account(address = METAPLEX_ID)]
     pub token_metadata_program: Program<'info, Metaplex>,
 }
 

--- a/pump/programs/pump/src/instructions/sell_token.rs
+++ b/pump/programs/pump/src/instructions/sell_token.rs
@@ -1,0 +1,92 @@
+use anchor_lang::prelude::*;
+#[allow(unused_imports)]
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{mint_to, MintTo, Token},
+    metadata::{
+        create_metadata_accounts_v3,
+        mpl_token_metadata::types::DataV2,
+        CreateMetadataAccountsV3,
+        Metadata as Metaplex,
+        mpl_token_metadata::ID as METAPLEX_ID,
+    },
+};
+// use anchor_lang::prelude::{Mint, TokenAccount}; // ✅ Fix: Use the correct types for Anchor compatibility
+
+use crate::state::{BondingCurve, GlobalConfig};
+use crate::constants::{ANCHOR_DISCRIMINATOR, BONDING_SEED};
+// use crate::utils::*; // assumes mint_token and create_metadata_account_v3 are here
+
+use anchor_spl::token::TokenAccount;
+use anchor_spl::token::Mint;
+
+
+#[derive(Account)]
+pub struct SellToken {
+    #[account(mut)]
+    pub signer: Signer<'info>
+
+    #[account(
+    seeds = ["bonding_curve_sol_escrow".as_bytes(), bonding_curve.key().as_ref()],
+    bump
+     )]
+    pub sol_ata: Account<'info, SystemAccount>
+
+        #[account(
+        init_if_needed,
+        payer = signer,
+        associated_token::mint  = token_mint,
+        associated_token::authority = signer,
+    )]
+    pub token_ata: Account<'info, TokenAccount>
+
+    #[account(
+        associated_token::mint = token_mint,
+        associated_token::authority = bonding_curve
+    )]
+    pub token_escrow: Account<'info, TokenAccount>
+
+     #[account(
+        seeds = ["bonding_curve_sol_escrow".as_bytes(), bonding_curve.key().as_ref()],
+        bump,
+    )]
+    pub sol_escrow: SystemAccount<'info>
+
+    #[account(
+        seeds = [b"BONDING_CURVE", token_mint.key().as_ref()],
+        bump = bonding_curve.bump
+    )]
+    pub bonding_curve: Account<'info, BondingCurve>
+
+    #[account(
+        constants = mint::decimal == 6,
+        constants = bonding_curve.token_mint == token_mint.key()
+    )]
+    pub token_mint: Account<'info, Mint>
+
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>
+    pub associated_token_program: Program<'info, AssociatedToken>
+}
+
+
+pub fn sell_token(ctx: Context<SellToken>, max_token:u64) -> Result<()> {
+    let signer = &["bonding_curve_sol_escrow".as_bytes(), ctx.acccounts.bonding_curve.key().as_ref(), &[ctx.bumps.sol_escrow]];
+    let signer_seeds = &[&signer[..]];
+    let bonding_curve = &mut ctx.acccounts.bonding_curve;   
+    let swapAmount: SwapAmount = bonding_curve.sell_logic(max_token);
+
+    //transfer logic
+    
+    /*
+    from:  AccountInfo<'info>,
+        to: AccountInfo<'info>,
+        vault_signer_seeds: &[&[&[u8]]],
+        amount: u64,
+        token_program: &AccountInfo<'info>,
+    
+    */
+
+    bonding_curve.transfer_token(ctx.acccounts.token_ata.to_account_info(), ctx.acccounts.token_escrow.to_account_info(), &[], swapAmount.tokan_to_send,ctx.acccounts.signer.to_account_info() ctx.acccounts.token_program.to_account_info());
+    bonding_curve.transfer_token(ctx.acccounts.sol_escrow.to_account_info(), ctx.acccounts.sol_ata.to_account_info,signer_seeds, swapAmount.max_sol,ctx.acccounts.bonding_curve.to_account_info() ctx.acccounts.token_program.to_account_info())
+}

--- a/pump/programs/pump/src/instructions/sell_token.rs
+++ b/pump/programs/pump/src/instructions/sell_token.rs
@@ -17,20 +17,11 @@ use crate::state::{BondingCurve, GlobalConfig};
 use crate::constants::{ANCHOR_DISCRIMINATOR, BONDING_SEED};
 // use crate::utils::*; // assumes mint_token and create_metadata_account_v3 are here
 
-use anchor_spl::token::TokenAccount;
-use anchor_spl::token::Mint;
-
 
 #[derive(Account)]
 pub struct SellToken {
     #[account(mut)]
     pub signer: Signer<'info>
-
-    #[account(
-    seeds = ["bonding_curve_sol_escrow".as_bytes(), bonding_curve.key().as_ref()],
-    bump
-     )]
-    pub sol_ata: Account<'info, SystemAccount>
 
         #[account(
         init_if_needed,
@@ -45,12 +36,6 @@ pub struct SellToken {
         associated_token::authority = bonding_curve
     )]
     pub token_escrow: Account<'info, TokenAccount>
-
-     #[account(
-        seeds = ["bonding_curve_sol_escrow".as_bytes(), bonding_curve.key().as_ref()],
-        bump,
-    )]
-    pub sol_escrow: SystemAccount<'info>
 
     #[account(
         seeds = [b"BONDING_CURVE", token_mint.key().as_ref()],
@@ -86,7 +71,9 @@ pub fn sell_token(ctx: Context<SellToken>, max_token:u64) -> Result<()> {
         token_program: &AccountInfo<'info>,
     
     */
+    let signer = &[b"BONDING_CURVE", ctx.acccounts.token_mint.key().as_ref(), &[ctx.acccounts.bonding_curve.bump]];
+    let signer_seeds:&[&[&[u8]]] = &[&signer[..]];
 
-    bonding_curve.transfer_token(ctx.acccounts.token_ata.to_account_info(), ctx.acccounts.token_escrow.to_account_info(), &[], swapAmount.tokan_to_send,ctx.acccounts.signer.to_account_info() ctx.acccounts.token_program.to_account_info());
-    bonding_curve.transfer_token(ctx.acccounts.sol_escrow.to_account_info(), ctx.acccounts.sol_ata.to_account_info,signer_seeds, swapAmount.max_sol,ctx.acccounts.bonding_curve.to_account_info() ctx.acccounts.token_program.to_account_info())
-}
+    bonding_curve.transfer_token(ctx.acccounts.token_ata.to_account_info(), ctx.acccounts.token_escrow.to_account_info(), &[], swapAmount.tokan_to_send, ctx.acccounts.token_program.to_account_info());
+    bonding_curve.transfer_sol(ctx.acccounts.bonding_curve.to_account_info(), ctx.acccounts.signer.to_account_info, signer_seeds, swapAmount.max_sol, ctx.acccounts.bonding_curve.to_account_info(), ctx.acccounts.system_program.to_account_info())
+} 

--- a/pump/programs/pump/src/state/bonding_curve.rs
+++ b/pump/programs/pump/src/state/bonding_curve.rs
@@ -1,4 +1,5 @@
 use anchor_lang::prelude::*;
+use anchor_lang::system_program::{transfer, Transfer};
 use anchor_spl::{
     associated_token::AssociatedToken,
     token::{mint_to, Mint, MintTo, Token, TokenAccount, transfer as spl_transfer, Transfer as SplTransfer},
@@ -223,6 +224,25 @@ impl<'info> BondingCurve {
             signer,
         );
         spl_transfer(cpi_ctx, amount)?;
+        Ok(())
+    }
+
+    pub fn transfer_sol(
+        from: AccountInfo<'info>,
+        to: AccountInfo<'info>,
+        signer: Option<&[&[&[u8]]]>,
+        amount: u64,
+        system_program: AccountInfo<'info>,
+    ) -> Result<()> {
+        let cpi_ctx = match signer {
+            Some(seeds) => CpiContext::new_with_signer(
+                system_program,
+                Transfer { from, to },
+                seeds,
+            ),
+            None => CpiContext::new(system_program, Transfer { from, to }),
+        };
+        transfer(cpi_ctx, amount)?;
         Ok(())
     }
 }

--- a/pump/programs/pump/src/state/bonding_curve.rs
+++ b/pump/programs/pump/src/state/bonding_curve.rs
@@ -1,219 +1,268 @@
+use anchor_lang::prelude::*;
 use anchor_spl::{
     associated_token::AssociatedToken,
-    token::{mint_to, Mint, MintTo, Token, TokenAccount},
+    token::{mint_to, Mint, MintTo, Token, TokenAccount, transfer as spl_transfer, Transfer as SplTransfer},
     metadata::{
         create_metadata_accounts_v3,
         mpl_token_metadata::types::DataV2,
-        CreateMetadataAccountsV3, 
+        CreateMetadataAccountsV3,
         Metadata as Metaplex,
     },
 };
-    use anchor_lang::prelude::*;
-    use crate::error::ErrorCode;
-    #[allow(unused_imports)]
+use crate::error::ErrorCode;
 use crate::constants::BONDING_SEED;
-    #[account]
-    #[derive(InitSpace)]
-    pub struct BondingCurve {
-        pub virtual_sol_reserve: u64,
-        pub virtual_token_reserve: u64,
-        pub token_sold: u64,
-        pub token_mint: Pubkey,
-        pub is_active: bool,
-        pub bump: u8,
+
+#[account]
+#[derive(InitSpace)]
+pub struct BondingCurve {
+    pub virtual_sol_reserve: u64,
+    pub virtual_token_reserve: u64,
+    pub token_sold: u64,
+    pub token_mint: Pubkey,
+    pub is_active: bool,
+    pub bump: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, PartialEq)]
+pub struct SwapAmount {
+    pub token_to_send: u64,
+    pub max_sol: u64,
+}
+
+impl<'info> BondingCurve {
+    pub fn init_bonding_curve(
+        &mut self,
+        virtual_sol_reserve: &u64,
+        virtual_token_reserve: &u64,
+        token_mint: &Pubkey,
+        bump: &u8,
+    ) -> Result<()> {
+        self.virtual_sol_reserve = *virtual_sol_reserve;
+        self.virtual_token_reserve = *virtual_token_reserve;
+        self.token_sold = 0;
+        self.token_mint = *token_mint;
+        self.is_active = true;
+        self.bump = *bump;
+        Ok(())
     }
-    impl<'info> BondingCurve {
-        pub fn init_bonding_curve(&mut self, virtual_sol_reserve: &u64, virtual_token_reserve:&u64, token_mint:&Pubkey, bump:&u8) -> Result<()> {
 
-            self.virtual_sol_reserve = *virtual_sol_reserve;
-            self.virtual_token_reserve = *virtual_token_reserve;
-            self.token_sold = 0;
-            self.token_mint = *token_mint;
-            self.is_active = true;
-            self.bump = *bump; // This should be set to the appropriate value later
-            Ok(())
-        }
+    pub fn update_token_reserve(&mut self, new_token_reserve: u64) -> Result<()> {
+        self.virtual_token_reserve = new_token_reserve;
+        Ok(())
+    }
 
-        pub fn get_virtual_sol_reserve(&self) -> u64 {
-            self.virtual_sol_reserve
-        }
+    pub fn update_sol_reserve(&mut self, new_sol_reserve: u64) -> Result<()> {
+        self.virtual_sol_reserve = new_sol_reserve;
+        Ok(())
+    }
 
-        pub fn get_virtual_token_reserve(&self) -> u64 {
-            self.virtual_token_reserve
-        }
+    pub fn increment_token_sold(&mut self, amount: u64) -> Result<()> {
+        self.token_sold = self
+            .token_sold
+            .checked_add(amount)
+            .ok_or(ErrorCode::OverflowDetected)?;
+        Ok(())
+    }
 
-        pub fn get_token_sold(&self) -> u64 {
-            self.token_sold
-        }
+    pub fn decrement_token_sold(&mut self, amount: u64) -> Result<()> {
+        self.token_sold = self
+            .token_sold
+            .checked_sub(amount)
+            .ok_or(ErrorCode::UnderflowDetected)?;
+        Ok(())
+    }
 
-        pub fn update_token_reserve(&mut self, new_token_reserve: u64) -> Result<()> {
-            self.virtual_token_reserve = new_token_reserve;
-            Ok(())
-        }
-        pub fn update_sol_reserve(&mut self, new_sol_reserve: u64) -> Result<()> {
-            self.virtual_sol_reserve = new_sol_reserve;
-            Ok(())
-        }
-        
-        pub fn increment_token_sold(&mut self, amount: u64) -> Result<()> {
-            self.token_sold = self.token_sold.checked_add(amount).ok_or(ErrorCode::OverflowDetected)?;
-            Ok(())
-        }
+    pub fn buy_logic(&mut self, max_sol: u64) -> Result<SwapAmount> {
+        require!(max_sol > 0, ErrorCode::InvalidSolAmount);
 
-        pub fn decrement_token_sold(&mut self, amount: u64) -> Result<()> {
-            self.token_sold = self.token_sold.checked_sub(amount).ok_or(ErrorCode::UnderflowDetected)?;
-            Ok(())
-        }
-        pub fn buy_logic(&mut self, max_sol:u64) -> Result<()> {
-            assert!(max_sol > 0,"{}", ErrorCode::InvalidSolAmount);
+        let k = self
+            .virtual_token_reserve
+            .checked_mul(self.virtual_sol_reserve)
+            .ok_or(ErrorCode::OverflowDetected)?;
 
-            let k = self.virtual_token_reserve.checked_mul(self.virtual_sol_reserve).ok_or(ErrorCode::OverflowDetected)?;
+        let new_sol_reserve = self
+            .virtual_sol_reserve
+            .checked_add(max_sol)
+            .ok_or(ErrorCode::OverflowDetected)?;
 
-            let token_reserve_after_buy = k.checked_div(self.virtual_sol_reserve.checked_add(max_sol).unwrap()).ok_or(ErrorCode::OverflowDetected)?;
+        let token_reserve_after_buy = k
+            .checked_div(new_sol_reserve)
+            .ok_or(ErrorCode::OverflowDetected)?;
 
-            let token_to_send = self.virtual_token_reserve.checked_sub(token_reserve_after_buy).ok_or(ErrorCode::UnderflowDetected)?;
-            
-            assert!(token_to_send > 0, "{}", ErrorCode::InvalidTokenAmount);
-            self.update_token_reserve(token_reserve_after_buy)?;
-            self.update_sol_reserve(self.virtual_sol_reserve.checked_add(max_sol).ok_or(ErrorCode::OverflowDetected)?)?;
-            self.increment_token_sold(token_to_send)?;
+        let token_to_send = self
+            .virtual_token_reserve
+            .checked_sub(token_reserve_after_buy)
+            .ok_or(ErrorCode::UnderflowDetected)?;
 
-            Ok(())
-        }
+        require!(token_to_send > 0, ErrorCode::InvalidTokenAmount);
 
-        pub fn sell_logic(&mut self, max_token:u64) -> Result<()> {
-            // Implement the logic for selling tokens back to the bonding curve
-            // This will involve calculating the price based on the bonding curve formula
-            // and updating the reserves accordingly.
-            assert!(max_token > 0, "{}", ErrorCode::InvalidTokenAmount);
-                    let k = self.virtual_token_reserve.checked_mul(self.virtual_sol_reserve).ok_or(ErrorCode::OverflowDetected)?;
+        self.update_token_reserve(token_reserve_after_buy)?;
+        self.update_sol_reserve(new_sol_reserve)?;
+        self.increment_token_sold(token_to_send)?;
 
-                        let sol_reserve_after_sell = k.checked_div(self.virtual_token_reserve.checked_add(max_token).unwrap()).ok_or(ErrorCode::OverflowDetected)?;
+        Ok(SwapAmount {
+            token_to_send,
+            max_sol,
+        })
+    }
 
-                let sol_to_send = self.virtual_sol_reserve.checked_sub(sol_reserve_after_sell).ok_or(ErrorCode::UnderflowDetected)?;
+    pub fn sell_logic(&mut self, max_token: u64) -> Result<SwapAmount> {
+        require!(max_token > 0, ErrorCode::InvalidTokenAmount);
 
-            assert!(sol_to_send > 0, "{}", ErrorCode::InvalidSolAmount);
+        let k = self
+            .virtual_token_reserve
+            .checked_mul(self.virtual_sol_reserve)
+            .ok_or(ErrorCode::OverflowDetected)?;
 
-            self.update_token_reserve(self.virtual_token_reserve.checked_add(max_token).ok_or(ErrorCode::OverflowDetected)?)?;
-            self.update_sol_reserve(sol_reserve_after_sell)?;
-            self.decrement_token_sold(max_token)?;
+        let new_token_reserve = self
+            .virtual_token_reserve
+            .checked_add(max_token)
+            .ok_or(ErrorCode::OverflowDetected)?;
 
-            Ok(())
-        }
-        // pub fn signer_seeds(&self) -> &[&[&[u8]]] {
-        //     let signer = &[BONDING_SEED.as_bytes(), self.token_mint.as_ref(), &[self.bump]];
-        //     let signer_seeds = &[signer[..]];
-        //     signer_seeds
-        // }
-        pub fn create_metadata_account(
-            & self,
-            name:&str, 
-            ticker:&str, 
-            uri:&str, 
-            token_metadata_program: &AccountInfo<'info>,
-            payer: &AccountInfo<'info>,
-            update_authority: &AccountInfo<'info>,
-            mint: &AccountInfo<'info>,
-            metadata: &AccountInfo<'info>,
-            mint_authority: &AccountInfo<'info>,
-            system_program: &AccountInfo<'info>,
-            rent: &AccountInfo<'info>,
-            signer_seeds: & [&[&[u8]]]
-        ){
-            let  token_data: DataV2 = DataV2{
-                name: name.to_string(),
-                symbol: ticker.to_string(),
-                uri: uri.to_string(),
-                seller_fee_basis_points: 0,
-                creators: None,
-                collection: None,
-                uses: None,
-            };
+        let sol_reserve_after_sell = k
+            .checked_div(new_token_reserve)
+            .ok_or(ErrorCode::OverflowDetected)?;
+
+        let sol_to_send = self
+            .virtual_sol_reserve
+            .checked_sub(sol_reserve_after_sell)
+            .ok_or(ErrorCode::UnderflowDetected)?;
+
+        require!(sol_to_send > 0, ErrorCode::InvalidSolAmount);
+
+        self.update_token_reserve(new_token_reserve)?;
+        self.update_sol_reserve(sol_reserve_after_sell)?;
+        self.decrement_token_sold(max_token)?;
+
+        Ok(SwapAmount {
+            token_to_send: max_token,
+            max_sol: sol_to_send,
+        })
+    }
+
+    pub fn create_metadata_account(
+        &self,
+        name: &str,
+        ticker: &str,
+        uri: &str,
+        token_metadata_program: &AccountInfo<'info>,
+        payer: &AccountInfo<'info>,
+        update_authority: &AccountInfo<'info>,
+        mint: &AccountInfo<'info>,
+        metadata: &AccountInfo<'info>,
+        mint_authority: &AccountInfo<'info>,
+        system_program: &AccountInfo<'info>,
+        rent: &AccountInfo<'info>,
+        signer_seeds: &[&[&[u8]]],
+    ) -> Result<()> {
+        let token_data = DataV2 {
+            name: name.to_string(),
+            symbol: ticker.to_string(),
+            uri: uri.to_string(),
+            seller_fee_basis_points: 0,
+            creators: None,
+            collection: None,
+            uses: None,
+        };
+
         let metadata_ctx = CpiContext::new_with_signer(
-        token_metadata_program.clone(),
-        CreateMetadataAccountsV3 {
-        metadata: metadata.clone(),
-        mint: mint.clone(),
-        mint_authority: mint_authority.clone(),
-        update_authority: update_authority.clone(),
-        payer: payer.clone(),
-        system_program: system_program.clone(),
-        rent: rent.clone(),
-        },
-        signer_seeds
-);
-   create_metadata_accounts_v3(
-        metadata_ctx,
-        token_data,
-        false, // is_mutable
-        true,  // update_authority_is_signer
-        None,  // optional collection details
-    );
-        }
-    pub fn mint_token(&self, token_program: &AccountInfo<'info>,to: &AccountInfo<'info>, mint: &AccountInfo<'info>, mint_authority: &AccountInfo<'info>, signer_seeds: &[&[&[u8]]]) -> Result<()> {
-    let cpi_ctx = CpiContext::new_with_signer(
-        token_program.clone(),
-        MintTo {
-            mint: mint.clone(),
-            to: to.clone(),
-            authority: mint_authority.clone(),
-        },
-        signer_seeds,
-    );
+            token_metadata_program.clone(),
+            CreateMetadataAccountsV3 {
+                metadata: metadata.clone(),
+                mint: mint.clone(),
+                mint_authority: mint_authority.clone(),
+                update_authority: update_authority.clone(),
+                payer: payer.clone(),
+                system_program: system_program.clone(),
+                rent: rent.clone(),
+            },
+            signer_seeds,
+        );
 
-    mint_to(cpi_ctx, 1_000_000_000)?;
-
-    Ok(())
-    }        
+        create_metadata_accounts_v3(metadata_ctx, token_data, false, true, None)?;
+        Ok(())
     }
 
+    pub fn mint_token(
+        &self,
+        token_program: &AccountInfo<'info>,
+        to: &AccountInfo<'info>,
+        mint: &AccountInfo<'info>,
+        mint_authority: &AccountInfo<'info>,
+        signer_seeds: &[&[&[u8]]],
+    ) -> Result<()> {
+        let cpi_ctx = CpiContext::new_with_signer(
+            token_program.clone(),
+            MintTo {
+                mint: mint.clone(),
+                to: to.clone(),
+                authority: mint_authority.clone(),
+            },
+            signer_seeds,
+        );
+
+        mint_to(cpi_ctx, 1_000_000_000)?;
+        Ok(())
+    }
+
+    pub fn transfer_token(
+        from: AccountInfo<'info>,
+        to: AccountInfo<'info>,
+        signer: &[&[&[u8]]],
+        amount: u64,
+        authority: AccountInfo<'info>,
+        token_program: AccountInfo<'info>,
+    ) -> Result<()> {
+        let cpi_ctx = CpiContext::new_with_signer(
+            token_program,
+            SplTransfer {
+                from: from.clone(),
+                to: to,
+                authority: authority.clone(),
+            },
+            signer,
+        );
+        spl_transfer(cpi_ctx, amount)?;
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anchor_lang::prelude::*;
 
- #[test]
+    #[test]
+    fn test_bonding_curve_buy_and_sell_logic() {
+        let mut bonding_curve = BondingCurve {
+            virtual_sol_reserve: 30,
+            virtual_token_reserve: 800_000_000,
+            token_sold: 0,
+            token_mint: Pubkey::default(),
+            is_active: true,
+            bump: 0,
+        };
 
- fn test_bonding_curve_buy_and_sell_logic() {
-    let mut bonding_curve = BondingCurve {
-        virtual_sol_reserve: 30,
-        virtual_token_reserve: 800_000_000,
-        token_sold: 0,
-        token_mint: Pubkey::default(),
-        is_active: true,
-        bump: 0,
-    };
+        let max_sol = 1;
+        let k = 30 * 800_000_000;
+        let expected_token_reserve_after_buy = k / (30 + max_sol);
+        let token_to_send = 800_000_000 - expected_token_reserve_after_buy;
 
-    // -------------------- BUY LOGIC --------------------
-    let max_sol = 1;
+        let buy_result = bonding_curve.buy_logic(max_sol);
+        assert!(buy_result.is_ok());
+        assert_eq!(bonding_curve.virtual_sol_reserve, 31);
+        assert_eq!(bonding_curve.virtual_token_reserve, expected_token_reserve_after_buy);
+        assert_eq!(bonding_curve.token_sold, token_to_send);
 
-    // Manual Calculation for BUY
-    let k = 30 * 800_000_000; // 24_000_000_000
-    let expected_token_reserve_after_buy = k / (30 + max_sol); // 24_000_000_000 / 31 = 774_193_548
-    let token_to_send = 800_000_000 - expected_token_reserve_after_buy; // 25_806_452
+        let max_token = 10_000_000;
+        let k = expected_token_reserve_after_buy * 31;
+        let new_token_reserve = expected_token_reserve_after_buy + max_token;
+        let expected_sol_reserve_after_sell = k / new_token_reserve;
+        let sol_to_send = 31 - expected_sol_reserve_after_sell;
 
-    let buy_result = bonding_curve.buy_logic(max_sol);
-    assert!(buy_result.is_ok());
-    assert_eq!(bonding_curve.virtual_sol_reserve, 31);
-    assert_eq!(bonding_curve.virtual_token_reserve, expected_token_reserve_after_buy);
-    assert_eq!(bonding_curve.token_sold, token_to_send);
-
-    // -------------------- SELL LOGIC --------------------
-    let max_token = 10_000_000;
-
-    // Manual Calculation for SELL
-    let k = expected_token_reserve_after_buy * 31; // updated virtual_token_reserve * virtual_sol_reserve
-    let new_token_reserve = expected_token_reserve_after_buy + max_token;
-    let expected_sol_reserve_after_sell = k / new_token_reserve;
-    let sol_to_send = 31 - expected_sol_reserve_after_sell;
-
-    let sell_result = bonding_curve.sell_logic(max_token);
-    assert!(sell_result.is_ok());
-
-    assert_eq!(bonding_curve.virtual_token_reserve, new_token_reserve);
-    assert_eq!(bonding_curve.virtual_sol_reserve, expected_sol_reserve_after_sell);
-    assert_eq!(bonding_curve.token_sold, token_to_send - max_token);
-
- }
+        let sell_result = bonding_curve.sell_logic(max_token);
+        assert!(sell_result.is_ok());
+        assert_eq!(bonding_curve.virtual_token_reserve, new_token_reserve);
+        assert_eq!(bonding_curve.virtual_sol_reserve, expected_sol_reserve_after_sell);
+        assert_eq!(bonding_curve.token_sold, token_to_send - max_token);
+    }
 }


### PR DESCRIPTION

Fixed the transfer_logic
```rs

    pub fn transfer_token(
            from: AccountInfo<'info>,
            to: AccountInfo<'info>,
            signer: &[&[&[u8]]],
            amount: u64,
            authority: AccountInfo<'info>,
            token_program: AccountInfo<'info>,
        ) -> Result<()> {
            let cpi_ctx = CpiContext::new_with_signer(
                token_program,
                SplTransfer {
                    from: from.clone(),
                    to: to,
                    authority: authority.clone(),
                },
                signer,
            );
            spl_transfer(cpi_ctx, amount)?;
            Ok(())
        }

        pub fn transfer_sol(
            from: AccountInfo<'info>,
            to: AccountInfo<'info>,
            signer: Option<&[&[&[u8]]]>,
            amount: u64,
            system_program: AccountInfo<'info>,
        ) -> Result<()> {
            let cpi_ctx = match signer {
                Some(seeds) => CpiContext::new_with_signer(
                    system_program,
                    Transfer { from, to },
                    seeds,
                ),
                None => CpiContext::new(system_program, Transfer { from, to }),
            };
            transfer(cpi_ctx, amount)?;
            Ok(())
        }

```